### PR TITLE
Add configurable GoXLR fader bank switching

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,16 +42,16 @@ Once connected, you should be able to configure actions.
 
 ### Fader Banks
 Add the **Toggle Fader Bank** action to switch any selection of the four hardware faders between two channel layouts.
-Each fader can be included or left unchanged independently. The Stream Deck key shows the active bank, its colour, and
-the current channel assignment. GoXLR scribble labels, icons, and fader colours can optionally follow the assigned
-channels as well.
+Each fader can be included or left unchanged independently. The Stream Deck key uses the plugin's standard light and
+dark GoXLR icons to show the active bank. GoXLR scribble labels, icons, and fader colours can optionally follow the
+assigned channels as well.
 
 The default layouts expose the eight standard input channels:
 
 * Bank 1: Mic, Chat, Music, System
 * Bank 2: Game, Console, Line In, Samples
 
-All fader-capable channels remain available in the property inspector, and both layouts and key colours are configurable.
+All fader-capable channels remain available in the property inspector, and both layouts are configurable.
 
 ## Troubleshooting
 ### The Icons are Red

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Join us for discussion related to the plugin on the [GoXLR Utiltiy](https://disc
 * Set / Adjust a Channel's Volume (includes submixes if available)
 * Set / Toggle a Route
 * Set / Toggle Fader Mute
+* Toggle selected faders between two configurable channel banks
 * Set / Toggle Microphone Mute
 * Set / Toggle FX Buttons
 
@@ -38,6 +39,19 @@ You should see a green 'Success' message if the plugin was able to connect, if n
 that the connection isn't being blocked by the firewall.
 
 Once connected, you should be able to configure actions.
+
+### Fader Banks
+Add the **Toggle Fader Bank** action to switch any selection of the four hardware faders between two channel layouts.
+Each fader can be included or left unchanged independently. The Stream Deck key shows the active bank, its colour, and
+the current channel assignment. GoXLR scribble labels, icons, and fader colours can optionally follow the assigned
+channels as well.
+
+The default layouts expose the eight standard input channels:
+
+* Bank 1: Mic, Chat, Music, System
+* Bank 2: Game, Console, Line In, Samples
+
+All fader-capable channels remain available in the property inspector, and both layouts and key colours are configurable.
 
 ## Troubleshooting
 ### The Icons are Red

--- a/src/com.frostycoolslug.goxlr-utility.sdPlugin/actions/goxlr-utility/property-inspector/fader-bank/inspector.html
+++ b/src/com.frostycoolslug.goxlr-utility.sdPlugin/actions/goxlr-utility/property-inspector/fader-bank/inspector.html
@@ -1,12 +1,13 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta charset="utf-8"/>
     <title>GoXLR Fader Bank</title>
     <link rel="stylesheet" href="../../../../libs/css/sdpi.css"/>
     <link rel="stylesheet" href="../global-settings/setup.css"/>
     <style>
         .bank-heading { margin-top: 10px; font-weight: 700; text-align: center; }
-        .fader-grid { display: grid; grid-template-columns: 46px 1fr 1fr; gap: 5px; align-items: center; width: 100%; }
+        .fader-grid { display: grid; grid-template-columns: 90px 1fr 1fr; gap: 5px; align-items: center; width: 100%; }
         .fader-grid select { min-width: 0; }
         .column-heading { color: #b8b8b8; font-size: 11px; text-align: center; }
         .hint { color: #b8b8b8; font-size: 11px; line-height: 1.35; padding: 8px; }
@@ -66,22 +67,22 @@
                 <div class="bank-heading">Fader assignments</div>
                 <div class="sdpi-item" style="max-width: none">
                     <div class="fader-grid">
-                        <div></div><div class="column-heading">BANK 1</div><div class="column-heading">BANK 2</div>
-                        <select name="use_a" title="Use fader A"><option value="yes">A ✓</option><option value="no">A –</option></select>
+                        <div class="column-heading">MODE</div><div class="column-heading">BANK 1</div><div class="column-heading">BANK 2</div>
+                        <select name="use_a" title="Switch or keep fader A"><option value="yes">A: switch</option><option value="no">A: keep</option></select>
                         <select name="bank1_a" class="channel-select" data-default="Mic"></select>
                         <select name="bank2_a" class="channel-select" data-default="Game"></select>
-                        <select name="use_b" title="Use fader B"><option value="yes">B ✓</option><option value="no">B –</option></select>
+                        <select name="use_b" title="Switch or keep fader B"><option value="yes">B: switch</option><option value="no">B: keep</option></select>
                         <select name="bank1_b" class="channel-select" data-default="Chat"></select>
                         <select name="bank2_b" class="channel-select" data-default="Console"></select>
-                        <select name="use_c" title="Use fader C"><option value="yes">C ✓</option><option value="no">C –</option></select>
+                        <select name="use_c" title="Switch or keep fader C"><option value="yes">C: switch</option><option value="no">C: keep</option></select>
                         <select name="bank1_c" class="channel-select" data-default="Music"></select>
                         <select name="bank2_c" class="channel-select" data-default="LineIn"></select>
-                        <select name="use_d" title="Use fader D"><option value="yes">D ✓</option><option value="no">D –</option></select>
+                        <select name="use_d" title="Switch or keep fader D"><option value="yes">D: switch</option><option value="no">D: keep</option></select>
                         <select name="bank1_d" class="channel-select" data-default="System"></select>
                         <select name="bank2_d" class="channel-select" data-default="Sample"></select>
                     </div>
                 </div>
-                <div class="hint">Select “–” to leave a fader unchanged. The key shows the active bank and current assignments. GoXLR scribble labels, icons, and colours can follow the selected channels.</div>
+                <div class="hint">Choose "keep" to leave a fader unchanged. Choose "switch" to assign its Bank 1 or Bank 2 channel when the key is pressed. The key shows the active bank and current assignments.</div>
             </div>
         </div>
     </form>

--- a/src/com.frostycoolslug.goxlr-utility.sdPlugin/actions/goxlr-utility/property-inspector/fader-bank/inspector.html
+++ b/src/com.frostycoolslug.goxlr-utility.sdPlugin/actions/goxlr-utility/property-inspector/fader-bank/inspector.html
@@ -68,6 +68,10 @@
                 </div>
                 <div class="hint">Choose "keep" to leave a fader unchanged. Choose "switch" to assign its Bank 1 or Bank 2 channel when the key is pressed. The standard light and dark GoXLR icons indicate the active bank.</div>
             </div>
+
+            <div class="hidden sdpi-item" id="refresh" style="max-width: none">
+                <button class="sdpi-item-value">Refresh</button>
+            </div>
         </div>
     </form>
 </div>

--- a/src/com.frostycoolslug.goxlr-utility.sdPlugin/actions/goxlr-utility/property-inspector/fader-bank/inspector.html
+++ b/src/com.frostycoolslug.goxlr-utility.sdPlugin/actions/goxlr-utility/property-inspector/fader-bank/inspector.html
@@ -41,22 +41,6 @@
 
             <div class="hidden" id="settings">
                 <div class="sdpi-item">
-                    <div class="sdpi-item-label">Bank 1</div>
-                    <input class="sdpi-item-value" name="bank1_name" maxlength="9" value="STANDARD"/>
-                </div>
-                <div class="sdpi-item">
-                    <div class="sdpi-item-label">Colour 1</div>
-                    <input class="sdpi-item-value" type="color" name="bank1_button_color" value="#007C91"/>
-                </div>
-                <div class="sdpi-item">
-                    <div class="sdpi-item-label">Bank 2</div>
-                    <input class="sdpi-item-value" name="bank2_name" maxlength="9" value="EXTRA"/>
-                </div>
-                <div class="sdpi-item">
-                    <div class="sdpi-item-label">Colour 2</div>
-                    <input class="sdpi-item-value" type="color" name="bank2_button_color" value="#9B3D91"/>
-                </div>
-                <div class="sdpi-item">
                     <div class="sdpi-item-label">GoXLR display</div>
                     <select class="sdpi-item-value" name="update_goxlr_appearance">
                         <option value="yes">Update labels and colours</option>
@@ -82,7 +66,7 @@
                         <select name="bank2_d" class="channel-select" data-default="Sample"></select>
                     </div>
                 </div>
-                <div class="hint">Choose "keep" to leave a fader unchanged. Choose "switch" to assign its Bank 1 or Bank 2 channel when the key is pressed. The key shows the active bank and current assignments.</div>
+                <div class="hint">Choose "keep" to leave a fader unchanged. Choose "switch" to assign its Bank 1 or Bank 2 channel when the key is pressed. The standard light and dark GoXLR icons indicate the active bank.</div>
             </div>
         </div>
     </form>

--- a/src/com.frostycoolslug.goxlr-utility.sdPlugin/actions/goxlr-utility/property-inspector/fader-bank/inspector.html
+++ b/src/com.frostycoolslug.goxlr-utility.sdPlugin/actions/goxlr-utility/property-inspector/fader-bank/inspector.html
@@ -1,0 +1,104 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>GoXLR Fader Bank</title>
+    <link rel="stylesheet" href="../../../../libs/css/sdpi.css"/>
+    <link rel="stylesheet" href="../global-settings/setup.css"/>
+    <style>
+        .bank-heading { margin-top: 10px; font-weight: 700; text-align: center; }
+        .fader-grid { display: grid; grid-template-columns: 46px 1fr 1fr; gap: 5px; align-items: center; width: 100%; }
+        .fader-grid select { min-width: 0; }
+        .column-heading { color: #b8b8b8; font-size: 11px; text-align: center; }
+        .hint { color: #b8b8b8; font-size: 11px; line-height: 1.35; padding: 8px; }
+    </style>
+</head>
+<body>
+<div class="sdpi-wrapper">
+    <div class="sdpi-item" id="please-wait">
+        <details class="message info"><summary>Please wait...</summary></details>
+    </div>
+
+    <div class="hidden alignCenter" id="configure">
+        <div class="sdpi-item" style="max-width: none">
+            <details class="message caution"><summary id="message"></summary></details>
+        </div>
+        <div class="sdpi-item" style="max-width: none">
+            <button class="sdpi-item-value" id="configure_button">Configure connection</button>
+        </div>
+    </div>
+
+    <form id="fader-bank-form">
+        <div id="main" class="hidden">
+            <div class="hidden sdpi-item" style="max-width: none" id="no-mixers">
+                <details class="message caution"><summary>No GoXLR devices detected</summary></details>
+            </div>
+
+            <div class="hidden sdpi-item" id="mixer">
+                <div class="sdpi-item-label">GoXLR</div>
+                <select class="sdpi-item-value" id="mixers" name="serial" disabled><option>Please wait...</option></select>
+            </div>
+
+            <div class="hidden" id="settings">
+                <div class="sdpi-item">
+                    <div class="sdpi-item-label">Bank 1</div>
+                    <input class="sdpi-item-value" name="bank1_name" maxlength="9" value="STANDARD"/>
+                </div>
+                <div class="sdpi-item">
+                    <div class="sdpi-item-label">Colour 1</div>
+                    <input class="sdpi-item-value" type="color" name="bank1_button_color" value="#007C91"/>
+                </div>
+                <div class="sdpi-item">
+                    <div class="sdpi-item-label">Bank 2</div>
+                    <input class="sdpi-item-value" name="bank2_name" maxlength="9" value="EXTRA"/>
+                </div>
+                <div class="sdpi-item">
+                    <div class="sdpi-item-label">Colour 2</div>
+                    <input class="sdpi-item-value" type="color" name="bank2_button_color" value="#9B3D91"/>
+                </div>
+                <div class="sdpi-item">
+                    <div class="sdpi-item-label">GoXLR display</div>
+                    <select class="sdpi-item-value" name="update_goxlr_appearance">
+                        <option value="yes">Update labels and colours</option>
+                        <option value="no">Keep current appearance</option>
+                    </select>
+                </div>
+
+                <div class="bank-heading">Fader assignments</div>
+                <div class="sdpi-item" style="max-width: none">
+                    <div class="fader-grid">
+                        <div></div><div class="column-heading">BANK 1</div><div class="column-heading">BANK 2</div>
+                        <select name="use_a" title="Use fader A"><option value="yes">A ✓</option><option value="no">A –</option></select>
+                        <select name="bank1_a" class="channel-select" data-default="Mic"></select>
+                        <select name="bank2_a" class="channel-select" data-default="Game"></select>
+                        <select name="use_b" title="Use fader B"><option value="yes">B ✓</option><option value="no">B –</option></select>
+                        <select name="bank1_b" class="channel-select" data-default="Chat"></select>
+                        <select name="bank2_b" class="channel-select" data-default="Console"></select>
+                        <select name="use_c" title="Use fader C"><option value="yes">C ✓</option><option value="no">C –</option></select>
+                        <select name="bank1_c" class="channel-select" data-default="Music"></select>
+                        <select name="bank2_c" class="channel-select" data-default="LineIn"></select>
+                        <select name="use_d" title="Use fader D"><option value="yes">D ✓</option><option value="no">D –</option></select>
+                        <select name="bank1_d" class="channel-select" data-default="System"></select>
+                        <select name="bank2_d" class="channel-select" data-default="Sample"></select>
+                    </div>
+                </div>
+                <div class="hint">Select “–” to leave a fader unchanged. The key shows the active bank and current assignments. GoXLR scribble labels, icons, and colours can follow the selected channels.</div>
+            </div>
+        </div>
+    </form>
+</div>
+
+<div class="sdpi-info-label hidden" style="top: -1000px" value=""></div>
+
+<script src="../../../../libs/js/constants.js"></script>
+<script src="../../../../libs/js/prototypes.js"></script>
+<script src="../../../../libs/js/timers.js"></script>
+<script src="../../../../libs/js/utils.js"></script>
+<script src="../../../../libs/js/events.js"></script>
+<script src="../../../../libs/js/api.js"></script>
+<script src="../../../../libs/js/property-inspector.js"></script>
+<script src="../../../../libs/js/dynamic-styles.js"></script>
+<script src="../../../../app/sockets.js"></script>
+<script src="inspector.js"></script>
+<script src="../global-settings/setup.inc.js"></script>
+</body>
+</html>

--- a/src/com.frostycoolslug.goxlr-utility.sdPlugin/actions/goxlr-utility/property-inspector/fader-bank/inspector.js
+++ b/src/com.frostycoolslug.goxlr-utility.sdPlugin/actions/goxlr-utility/property-inspector/fader-bank/inspector.js
@@ -1,0 +1,64 @@
+/// <reference path="../../../../libs/js/property-inspector.js" />
+/// <reference path="../../../../libs/js/utils.js" />
+
+const websocket = new Websocket();
+let pluginSettings;
+
+const channelOptions = [
+    ['Mic', 'Mic'],
+    ['Chat', 'Chat'],
+    ['Music', 'Music'],
+    ['System', 'System'],
+    ['Game', 'Game'],
+    ['Console', 'Console'],
+    ['LineIn', 'Line In'],
+    ['Sample', 'Samples'],
+    ['Headphones', 'Headphones'],
+    ['MicMonitor', 'Mic Monitor'],
+    ['LineOut', 'Line Out']
+];
+
+function runPlugin() {
+    let mixers = Object.keys(device.mixers || {});
+    if (mixers.length === 0) {
+        document.querySelector('#no-mixers').classList.remove('hidden');
+        return;
+    }
+
+    let serialList = document.querySelector('#mixers');
+    serialList.innerHTML = '';
+    for (let serial of mixers) {
+        let option = document.createElement('option');
+        option.text = serial;
+        option.value = serial;
+        serialList.add(option);
+    }
+    serialList.disabled = false;
+    if (mixers.length > 1) {
+        document.querySelector('#mixer').classList.remove('hidden');
+    }
+
+    for (let select of document.querySelectorAll('.channel-select')) {
+        select.innerHTML = '';
+        for (let [value, label] of channelOptions) {
+            let option = document.createElement('option');
+            option.value = value;
+            option.text = label;
+            select.add(option);
+        }
+        select.value = select.dataset.default;
+    }
+
+    document.querySelector('#settings').classList.remove('hidden');
+    Utils.setFormValue(pluginSettings, document.querySelector('#fader-bank-form'));
+    saveSettings();
+    websocket.disconnect();
+}
+
+function saveSettings() {
+    pluginSettings = Utils.getFormValue(document.querySelector('#fader-bank-form'));
+    $PI.setSettings(pluginSettings);
+}
+
+document.querySelector('#fader-bank-form').addEventListener('change', saveSettings);
+document.querySelector('#fader-bank-form').addEventListener('input', Utils.debounce(200, saveSettings));

--- a/src/com.frostycoolslug.goxlr-utility.sdPlugin/actions/goxlr-utility/property-inspector/fader-bank/inspector.js
+++ b/src/com.frostycoolslug.goxlr-utility.sdPlugin/actions/goxlr-utility/property-inspector/fader-bank/inspector.js
@@ -3,6 +3,20 @@
 
 const websocket = new Websocket();
 let pluginSettings;
+let initialising = true;
+
+const inspectorDefaults = {
+    serial: '',
+    bank1_name: 'STANDARD',
+    bank2_name: 'EXTRA',
+    bank1_button_color: '#007C91',
+    bank2_button_color: '#9B3D91',
+    update_goxlr_appearance: 'yes',
+    use_a: 'yes', bank1_a: 'Mic', bank2_a: 'Game',
+    use_b: 'yes', bank1_b: 'Chat', bank2_b: 'Console',
+    use_c: 'yes', bank1_c: 'Music', bank2_c: 'LineIn',
+    use_d: 'yes', bank1_d: 'System', bank2_d: 'Sample'
+};
 
 const channelOptions = [
     ['Mic', 'Mic'],
@@ -50,8 +64,13 @@ function runPlugin() {
     }
 
     document.querySelector('#settings').classList.remove('hidden');
+    pluginSettings = Object.assign({}, inspectorDefaults, pluginSettings || {});
+    if (!pluginSettings.serial) {
+        pluginSettings.serial = mixers[0];
+    }
     Utils.setFormValue(pluginSettings, document.querySelector('#fader-bank-form'));
-    saveSettings();
+    $PI.setSettings(pluginSettings);
+    initialising = false;
     websocket.disconnect();
 }
 
@@ -60,5 +79,10 @@ function saveSettings() {
     $PI.setSettings(pluginSettings);
 }
 
-document.querySelector('#fader-bank-form').addEventListener('change', saveSettings);
-document.querySelector('#fader-bank-form').addEventListener('input', Utils.debounce(200, saveSettings));
+const saveSettingsDebounced = Utils.debounce(200, saveSettings);
+document.querySelector('#fader-bank-form').addEventListener('change', () => {
+    if (!initialising) saveSettings();
+});
+document.querySelector('#fader-bank-form').addEventListener('input', () => {
+    if (!initialising) saveSettingsDebounced();
+});

--- a/src/com.frostycoolslug.goxlr-utility.sdPlugin/actions/goxlr-utility/property-inspector/fader-bank/inspector.js
+++ b/src/com.frostycoolslug.goxlr-utility.sdPlugin/actions/goxlr-utility/property-inspector/fader-bank/inspector.js
@@ -29,6 +29,8 @@ const channelOptions = [
 ];
 
 function runPlugin() {
+    document.querySelector('#refresh').classList.remove('hidden');
+
     let mixers = Object.keys(device.mixers || {});
     if (mixers.length === 0) {
         document.querySelector('#no-mixers').classList.remove('hidden');

--- a/src/com.frostycoolslug.goxlr-utility.sdPlugin/actions/goxlr-utility/property-inspector/fader-bank/inspector.js
+++ b/src/com.frostycoolslug.goxlr-utility.sdPlugin/actions/goxlr-utility/property-inspector/fader-bank/inspector.js
@@ -7,10 +7,6 @@ let initialising = true;
 
 const inspectorDefaults = {
     serial: '',
-    bank1_name: 'STANDARD',
-    bank2_name: 'EXTRA',
-    bank1_button_color: '#007C91',
-    bank2_button_color: '#9B3D91',
     update_goxlr_appearance: 'yes',
     use_a: 'yes', bank1_a: 'Mic', bank2_a: 'Game',
     use_b: 'yes', bank1_b: 'Chat', bank2_b: 'Console',

--- a/src/com.frostycoolslug.goxlr-utility.sdPlugin/app.html
+++ b/src/com.frostycoolslug.goxlr-utility.sdPlugin/app.html
@@ -37,6 +37,7 @@
     <script src="app/toggle-mute.js"></script>
     <script src="app/toggle-mic-mute.js"></script>
     <script src="app/toggle-mix-assignment.js"></script>
+    <script src="app/fader-bank.js"></script>
     <script src="app/toggle-fx.js"></script>
     <script src="app/load-effect-bank.js"></script>
     <script src="app.js"></script>

--- a/src/com.frostycoolslug.goxlr-utility.sdPlugin/app.js
+++ b/src/com.frostycoolslug.goxlr-utility.sdPlugin/app.js
@@ -64,6 +64,7 @@ function utilityOffline() {
     encoderVolumeMonitorExternalStateChange();
     basicExternalStateChange();
     mixAssignmentExternalStateChange();
+    faderBankExternalStateChange();
 }
 
 function utilityOnline() {
@@ -77,6 +78,7 @@ function utilityOnline() {
     encoderVolumeMonitorExternalStateChange();
     basicExternalStateChange();
     mixAssignmentExternalStateChange();
+    faderBankExternalStateChange();
 }
 
 function retryConnection() {

--- a/src/com.frostycoolslug.goxlr-utility.sdPlugin/app/fader-bank.js
+++ b/src/com.frostycoolslug.goxlr-utility.sdPlugin/app/fader-bank.js
@@ -1,0 +1,234 @@
+const faderBankAction = new Action('com.frostycoolslug.goxlr-utility.fader-bank');
+const faderBankMonitors = {};
+const faderBankSwitching = new Set();
+
+const faderBankDefaults = {
+    serial: '',
+    bank1_name: 'STANDARD',
+    bank2_name: 'EXTRA',
+    bank1_button_color: '#007C91',
+    bank2_button_color: '#9B3D91',
+    update_goxlr_appearance: 'yes',
+    use_a: 'yes',
+    bank1_a: 'Mic',
+    bank2_a: 'Game',
+    use_b: 'yes',
+    bank1_b: 'Chat',
+    bank2_b: 'Console',
+    use_c: 'yes',
+    bank1_c: 'Music',
+    bank2_c: 'LineIn',
+    use_d: 'yes',
+    bank1_d: 'System',
+    bank2_d: 'Sample'
+};
+
+const faderChannelAppearance = {
+    Mic: {label: 'Mic', short: 'MIC', faderColour: '00FFFF', scribbleColour: '00FFFF', icon: 'mic.png'},
+    Chat: {label: 'Voice Chat', short: 'CHAT', faderColour: 'FF2800', scribbleColour: 'FF1D00', icon: 'person.png'},
+    Music: {label: 'Music', short: 'MUSIC', faderColour: 'FFC300', scribbleColour: 'FFC300', icon: 'music.png'},
+    System: {label: 'System', short: 'SYS', faderColour: '533CFF', scribbleColour: 'B2ABFF', icon: 'level.png'},
+    Game: {label: 'Game', short: 'GAME', faderColour: '00E676', scribbleColour: '00E676', icon: 'scale.png'},
+    Console: {label: 'Console', short: 'CONS', faderColour: 'FF4F81', scribbleColour: 'FF4F81', icon: 'headphone.png'},
+    LineIn: {label: 'Line In', short: 'LINE', faderColour: '00B8D4', scribbleColour: '00B8D4', icon: 'level.png'},
+    Sample: {label: 'Samples', short: 'SAMP', faderColour: 'FF8C00', scribbleColour: 'FF8C00', icon: 'music.png'},
+    Headphones: {label: 'Headphones', short: 'PHONE', faderColour: '00AEEF', scribbleColour: '00AEEF', icon: 'headphone.png'},
+    MicMonitor: {label: 'Mic Monitor', short: 'MON', faderColour: '00FFFF', scribbleColour: '00FFFF', icon: 'mic3.png'},
+    LineOut: {label: 'Line Out', short: 'OUT', faderColour: '8D6E63', scribbleColour: '8D6E63', icon: 'level.png'}
+};
+
+const faderNames = ['A', 'B', 'C', 'D'];
+
+function faderBankExternalStateChange() {
+    for (let monitor of Object.values(faderBankMonitors)) {
+        monitor.setDisplay();
+    }
+}
+
+function normaliseFaderBankSettings(settings) {
+    let result = Object.assign({}, faderBankDefaults, settings || {});
+    if (!result.serial && status && status.mixers) {
+        result.serial = Object.keys(status.mixers)[0] || '';
+    }
+    return result;
+}
+
+function selectedFaders(settings) {
+    return faderNames.filter((fader) => settings[`use_${fader.toLowerCase()}`] !== 'no');
+}
+
+function getBankChannel(settings, bank, fader) {
+    return settings[`bank${bank}_${fader.toLowerCase()}`];
+}
+
+function activeFaderBank(settings) {
+    if (!status || !status.mixers || !status.mixers[settings.serial]) {
+        return 0;
+    }
+
+    let faders = selectedFaders(settings);
+    if (faders.length === 0) {
+        return 0;
+    }
+
+    let faderStatus = status.mixers[settings.serial].fader_status;
+    let bankOne = faders.every((fader) => faderStatus[fader] && faderStatus[fader].channel === getBankChannel(settings, 1, fader));
+    let bankTwo = faders.every((fader) => faderStatus[fader] && faderStatus[fader].channel === getBankChannel(settings, 2, fader));
+
+    if (bankOne) return 1;
+    if (bankTwo) return 2;
+    return 0;
+}
+
+async function applyFaderBank(settings, bank) {
+    let commands = [];
+
+    for (let fader of selectedFaders(settings)) {
+        let channel = getBankChannel(settings, bank, fader);
+        let appearance = faderChannelAppearance[channel] || {
+            label: channel,
+            short: channel,
+            faderColour: 'FFFFFF',
+            scribbleColour: 'FFFFFF',
+            icon: ''
+        };
+
+        commands.push({SetFader: [fader, channel]});
+
+        if (settings.update_goxlr_appearance !== 'no') {
+            let scribble = `Scribble${faderNames.indexOf(fader) + 1}`;
+            commands.push({SetScribbleText: [fader, appearance.label]});
+            commands.push({SetScribbleIcon: [fader, appearance.icon]});
+            commands.push({SetFaderColours: [fader, 'FFFFFF', appearance.faderColour]});
+            commands.push({SetSimpleColour: [scribble, appearance.scribbleColour]});
+        }
+    }
+
+    for (let command of commands) {
+        await websocket.send_command(settings.serial, command);
+    }
+}
+
+faderBankAction.onKeyUp(async ({context, payload}) => {
+    let settings = normaliseFaderBankSettings(payload.settings);
+    if (!status || !status.mixers || !status.mixers[settings.serial] || selectedFaders(settings).length === 0) {
+        $SD.showAlert(context);
+        return;
+    }
+
+    if (faderBankSwitching.has(context)) {
+        return;
+    }
+
+    faderBankSwitching.add(context);
+    let bank = activeFaderBank(settings) === 1 ? 2 : 1;
+    try {
+        await applyFaderBank(settings, bank);
+        if (faderBankMonitors[context]) {
+            faderBankMonitors[context].setDisplay();
+        }
+        $SD.showOk(context);
+    } catch (error) {
+        console.error('Unable to switch GoXLR fader bank', error);
+        $SD.showAlert(context);
+    } finally {
+        faderBankSwitching.delete(context);
+    }
+});
+
+faderBankAction.onDidReceiveSettings(({context, payload}) => {
+    createFaderBankMonitor(context, payload.settings);
+});
+
+faderBankAction.onWillAppear(({context, payload}) => {
+    createFaderBankMonitor(context, payload.settings);
+});
+
+faderBankAction.onWillDisappear(({context}) => {
+    if (faderBankMonitors[context]) {
+        faderBankMonitors[context].destroy();
+        delete faderBankMonitors[context];
+    }
+    faderBankSwitching.delete(context);
+});
+
+function createFaderBankMonitor(context, rawSettings) {
+    let settings = normaliseFaderBankSettings(rawSettings);
+    if (faderBankMonitors[context]) {
+        faderBankMonitors[context].destroy();
+    }
+    faderBankMonitors[context] = new FaderBankMonitor(context, settings);
+    faderBankMonitors[context].setDisplay();
+}
+
+class FaderBankMonitor {
+    context = undefined;
+    settings = undefined;
+    faderPath = undefined;
+    #eventHandle = () => {};
+
+    constructor(context, settings) {
+        this.context = context;
+        this.settings = settings;
+        this.faderPath = `/mixers/${settings.serial}/fader_status`;
+
+        let self = this;
+        this.#eventHandle = function(event) {
+            if (event.patch.path.startsWith(self.faderPath)) {
+                self.setDisplay();
+            }
+        };
+        eventTarget.addEventListener('patch', this.#eventHandle);
+    }
+
+    destroy() {
+        eventTarget.removeEventListener('patch', this.#eventHandle);
+    }
+
+    setDisplay() {
+        if (!status || !status.mixers || !status.mixers[this.settings.serial]) {
+            $SD.setImage(this.context, RedIcon);
+            return;
+        }
+
+        let bank = activeFaderBank(this.settings);
+        let mixer = status.mixers[this.settings.serial];
+        let background = bank === 1 ? this.settings.bank1_button_color :
+            (bank === 2 ? this.settings.bank2_button_color : '#343A40');
+        let bankName = bank === 1 ? this.settings.bank1_name :
+            (bank === 2 ? this.settings.bank2_name : 'MIXED');
+        let rows = [];
+
+        for (let fader of selectedFaders(this.settings)) {
+            let channel = mixer.fader_status[fader] ? mixer.fader_status[fader].channel : '?';
+            let appearance = faderChannelAppearance[channel] || {short: channel};
+            rows.push(`${fader}  ${appearance.short}`);
+        }
+
+        let lineHeight = rows.length > 3 ? 19 : 22;
+        let startY = rows.length > 3 ? 65 : 70;
+        let rowMarkup = rows.map((row, index) =>
+            `<text x="72" y="${startY + index * lineHeight}" text-anchor="middle" fill="#FFFFFF" font-family="sans-serif" font-size="${rows.length > 3 ? 14 : 16}" font-weight="700">${escapeFaderBankXml(row)}</text>`
+        ).join('');
+
+        let svg = `<svg xmlns="http://www.w3.org/2000/svg" width="144" height="144" viewBox="0 0 144 144">` +
+            `<rect width="144" height="144" rx="12" fill="${escapeFaderBankXml(background)}"/>` +
+            `<rect x="7" y="7" width="130" height="130" rx="9" fill="none" stroke="#FFFFFF" stroke-opacity="0.45" stroke-width="3"/>` +
+            `<text x="72" y="28" text-anchor="middle" fill="#FFFFFF" font-family="sans-serif" font-size="13" font-weight="700">BANK ${bank || '?'}</text>` +
+            `<text x="72" y="49" text-anchor="middle" fill="#FFFFFF" font-family="sans-serif" font-size="16" font-weight="800">${escapeFaderBankXml(bankName)}</text>` +
+            rowMarkup + `</svg>`;
+
+        let svgBase64 = btoa(unescape(encodeURIComponent(svg)));
+        $SD.setImage(this.context, `data:image/svg+xml;base64,${svgBase64}`);
+    }
+}
+
+function escapeFaderBankXml(value) {
+    return String(value).replace(/[&<>"']/g, (character) => ({
+        '&': '&amp;',
+        '<': '&lt;',
+        '>': '&gt;',
+        '"': '&quot;',
+        "'": '&apos;'
+    })[character]);
+}

--- a/src/com.frostycoolslug.goxlr-utility.sdPlugin/app/fader-bank.js
+++ b/src/com.frostycoolslug.goxlr-utility.sdPlugin/app/fader-bank.js
@@ -119,10 +119,8 @@ faderBankAction.onKeyUp(async ({context, payload}) => {
     let bank = activeFaderBank(settings) === 1 ? 2 : 1;
     try {
         await applyFaderBank(settings, bank);
-        if (faderBankMonitors[context]) {
-            faderBankMonitors[context].setDisplay();
-        }
-        $SD.showOk(context);
+        $SD.setImage(context);
+        $SD.setState(context, bank === 2 ? 1 : 0);
     } catch (error) {
         console.error('Unable to switch GoXLR fader bank', error);
         $SD.showAlert(context);
@@ -169,7 +167,7 @@ class FaderBankMonitor {
 
         let self = this;
         this.#eventHandle = function(event) {
-            if (event.patch.path.startsWith(self.faderPath)) {
+            if (event.patch.path.startsWith(self.faderPath) && !faderBankSwitching.has(self.context)) {
                 self.setDisplay();
             }
         };

--- a/src/com.frostycoolslug.goxlr-utility.sdPlugin/app/fader-bank.js
+++ b/src/com.frostycoolslug.goxlr-utility.sdPlugin/app/fader-bank.js
@@ -4,10 +4,6 @@ const faderBankSwitching = new Set();
 
 const faderBankDefaults = {
     serial: '',
-    bank1_name: 'STANDARD',
-    bank2_name: 'EXTRA',
-    bank1_button_color: '#007C91',
-    bank2_button_color: '#9B3D91',
     update_goxlr_appearance: 'yes',
     use_a: 'yes',
     bank1_a: 'Mic',
@@ -24,17 +20,17 @@ const faderBankDefaults = {
 };
 
 const faderChannelAppearance = {
-    Mic: {label: 'Mic', short: 'MIC', faderColour: '00FFFF', scribbleColour: '00FFFF', icon: 'mic.png'},
-    Chat: {label: 'Voice Chat', short: 'CHAT', faderColour: 'FF2800', scribbleColour: 'FF1D00', icon: 'person.png'},
-    Music: {label: 'Music', short: 'MUSIC', faderColour: 'FFC300', scribbleColour: 'FFC300', icon: 'music.png'},
-    System: {label: 'System', short: 'SYS', faderColour: '533CFF', scribbleColour: 'B2ABFF', icon: 'level.png'},
-    Game: {label: 'Game', short: 'GAME', faderColour: '00E676', scribbleColour: '00E676', icon: 'scale.png'},
-    Console: {label: 'Console', short: 'CONS', faderColour: 'FF4F81', scribbleColour: 'FF4F81', icon: 'headphone.png'},
-    LineIn: {label: 'Line In', short: 'LINE', faderColour: '00B8D4', scribbleColour: '00B8D4', icon: 'level.png'},
-    Sample: {label: 'Samples', short: 'SAMP', faderColour: 'FF8C00', scribbleColour: 'FF8C00', icon: 'music.png'},
-    Headphones: {label: 'Headphones', short: 'PHONE', faderColour: '00AEEF', scribbleColour: '00AEEF', icon: 'headphone.png'},
-    MicMonitor: {label: 'Mic Monitor', short: 'MON', faderColour: '00FFFF', scribbleColour: '00FFFF', icon: 'mic3.png'},
-    LineOut: {label: 'Line Out', short: 'OUT', faderColour: '8D6E63', scribbleColour: '8D6E63', icon: 'level.png'}
+    Mic: {label: 'Mic', faderColour: '00FFFF', scribbleColour: '00FFFF', icon: 'mic.png'},
+    Chat: {label: 'Voice Chat', faderColour: 'FF2800', scribbleColour: 'FF1D00', icon: 'person.png'},
+    Music: {label: 'Music', faderColour: 'FFC300', scribbleColour: 'FFC300', icon: 'music.png'},
+    System: {label: 'System', faderColour: '533CFF', scribbleColour: 'B2ABFF', icon: 'level.png'},
+    Game: {label: 'Game', faderColour: '00E676', scribbleColour: '00E676', icon: 'scale.png'},
+    Console: {label: 'Console', faderColour: 'FF4F81', scribbleColour: 'FF4F81', icon: 'headphone.png'},
+    LineIn: {label: 'Line In', faderColour: '00B8D4', scribbleColour: '00B8D4', icon: 'level.png'},
+    Sample: {label: 'Samples', faderColour: 'FF8C00', scribbleColour: 'FF8C00', icon: 'music.png'},
+    Headphones: {label: 'Headphones', faderColour: '00AEEF', scribbleColour: '00AEEF', icon: 'headphone.png'},
+    MicMonitor: {label: 'Mic Monitor', faderColour: '00FFFF', scribbleColour: '00FFFF', icon: 'mic3.png'},
+    LineOut: {label: 'Line Out', faderColour: '8D6E63', scribbleColour: '8D6E63', icon: 'level.png'}
 };
 
 const faderNames = ['A', 'B', 'C', 'D'];
@@ -87,7 +83,6 @@ async function applyFaderBank(settings, bank) {
         let channel = getBankChannel(settings, bank, fader);
         let appearance = faderChannelAppearance[channel] || {
             label: channel,
-            short: channel,
             faderColour: 'FFFFFF',
             scribbleColour: 'FFFFFF',
             icon: ''
@@ -192,43 +187,12 @@ class FaderBankMonitor {
         }
 
         let bank = activeFaderBank(this.settings);
-        let mixer = status.mixers[this.settings.serial];
-        let background = bank === 1 ? this.settings.bank1_button_color :
-            (bank === 2 ? this.settings.bank2_button_color : '#343A40');
-        let bankName = bank === 1 ? this.settings.bank1_name :
-            (bank === 2 ? this.settings.bank2_name : 'MIXED');
-        let rows = [];
-
-        for (let fader of selectedFaders(this.settings)) {
-            let channel = mixer.fader_status[fader] ? mixer.fader_status[fader].channel : '?';
-            let appearance = faderChannelAppearance[channel] || {short: channel};
-            rows.push(`${fader}  ${appearance.short}`);
+        if (bank === 0) {
+            $SD.setImage(this.context, RedIcon);
+            return;
         }
 
-        let lineHeight = rows.length > 3 ? 19 : 22;
-        let startY = rows.length > 3 ? 65 : 70;
-        let rowMarkup = rows.map((row, index) =>
-            `<text x="72" y="${startY + index * lineHeight}" text-anchor="middle" fill="#FFFFFF" font-family="sans-serif" font-size="${rows.length > 3 ? 14 : 16}" font-weight="700">${escapeFaderBankXml(row)}</text>`
-        ).join('');
-
-        let svg = `<svg xmlns="http://www.w3.org/2000/svg" width="144" height="144" viewBox="0 0 144 144">` +
-            `<rect width="144" height="144" rx="12" fill="${escapeFaderBankXml(background)}"/>` +
-            `<rect x="7" y="7" width="130" height="130" rx="9" fill="none" stroke="#FFFFFF" stroke-opacity="0.45" stroke-width="3"/>` +
-            `<text x="72" y="28" text-anchor="middle" fill="#FFFFFF" font-family="sans-serif" font-size="13" font-weight="700">BANK ${bank || '?'}</text>` +
-            `<text x="72" y="49" text-anchor="middle" fill="#FFFFFF" font-family="sans-serif" font-size="16" font-weight="800">${escapeFaderBankXml(bankName)}</text>` +
-            rowMarkup + `</svg>`;
-
-        let svgBase64 = btoa(unescape(encodeURIComponent(svg)));
-        $SD.setImage(this.context, `data:image/svg+xml;base64,${svgBase64}`);
+        $SD.setImage(this.context);
+        $SD.setState(this.context, bank === 2 ? 1 : 0);
     }
-}
-
-function escapeFaderBankXml(value) {
-    return String(value).replace(/[&<>"']/g, (character) => ({
-        '&': '&amp;',
-        '<': '&lt;',
-        '>': '&gt;',
-        '"': '&quot;',
-        "'": '&apos;'
-    })[character]);
 }

--- a/src/com.frostycoolslug.goxlr-utility.sdPlugin/manifest.json
+++ b/src/com.frostycoolslug.goxlr-utility.sdPlugin/manifest.json
@@ -150,6 +150,9 @@
 			"States": [
 				{
 					"Image": "actions/goxlr-utility/assets/goxlr-white"
+				},
+				{
+					"Image": "actions/goxlr-utility/assets/goxlr-grey"
 				}
 			],
 			"Tooltip": "Switches selected GoXLR faders between two channel banks",

--- a/src/com.frostycoolslug.goxlr-utility.sdPlugin/manifest.json
+++ b/src/com.frostycoolslug.goxlr-utility.sdPlugin/manifest.json
@@ -6,7 +6,7 @@
 	"Name": "GoXLR Utility for StreamDeck",
 	"Icon": "actions/goxlr-utility/assets/goxlr-white",
 	"URL": "https://github.com/frostycoolslug/goxlr-utility-streamdeck",
-	"Version": "0.4.3",
+	"Version": "0.4.4",
 	"Software": {
 		"MinimumVersion": "5.0"
 	},
@@ -143,6 +143,18 @@
 			"Tooltip": "Configures the Mute Setting for the Microphone",
 			"UUID": "com.frostycoolslug.goxlr-utility.toggle-mix-assignment",
 			"PropertyInspectorPath": "actions/goxlr-utility/property-inspector/toggle-mix-assignment/inspector.html"
+		},
+		{
+			"Icon": "actions/goxlr-utility/assets/goxlr-white",
+			"Name": "Toggle Fader Bank",
+			"States": [
+				{
+					"Image": "actions/goxlr-utility/assets/goxlr-white"
+				}
+			],
+			"Tooltip": "Switches selected GoXLR faders between two channel banks",
+			"UUID": "com.frostycoolslug.goxlr-utility.fader-bank",
+			"PropertyInspectorPath": "actions/goxlr-utility/property-inspector/fader-bank/inspector.html"
 		},
 		{
 			"Icon": "actions/goxlr-utility/assets/goxlr-white",


### PR DESCRIPTION
## Summary

- add a `Toggle Fader Bank` action that switches selected physical faders between two configurable channel banks
- support all 11 GoXLR fader-capable channels and allow individual faders to remain unchanged
- optionally update the GoXLR scribble labels, icons, and colours to follow the selected channels
- use the plugin's standard light/dark GoXLR icons for the active bank and reserve the red icon for actual error or mixed states
- add a refresh control consistent with the existing property inspectors

## Testing

- verified JavaScript syntax with `node --check`
- ran a simulated four-fader bank transition, including every intermediate GoXLR status patch, and confirmed that it emits no success overlay or transient red state
- tested in OpenDeck 7.1.0 on Bazzite with GoXLR Utility using:
  - Bank 1: Mic, Chat, Music, System
  - Bank 2: Game, Console, Line In, Samples
- verified that reopening the property inspector preserves the configured mappings

## AI disclosure

This contribution was developed with assistance from OpenAI Codex. The resulting code was tested locally with OpenDeck and GoXLR Utility on Bazzite.
